### PR TITLE
Allow user to pass MAC address to knife xapi guest create. 

### DIFF
--- a/lib/chef/knife/xapi_base.rb
+++ b/lib/chef/knife/xapi_base.rb
@@ -243,7 +243,12 @@ class Chef::Knife
 
     # generate a random mac address
     def generate_mac
-      ("%02x"%(rand(64)*4|2))+(0..4).inject(""){|s,x|s+":%02x"%rand(256)}
+       
+      if locate_config_value(:macaddress).nil?
+        ("%02x"%(rand(64)*4|2))+(0..4).inject(""){|s,x|s+":%02x"%rand(256)}
+      else
+        locate_config_value(:macaddress)
+      end
     end
 
     # add a new vif

--- a/lib/chef/knife/xapi_guest_create.rb
+++ b/lib/chef/knife/xapi_guest_create.rb
@@ -62,6 +62,12 @@ class Chef
         :description => "Install repo for this template (if needed)",
         :proc => Proc.new { |key| Chef::Config[:knife][:install_repo] = key }
 
+      option :macaddress,
+        :short => "-m MAC Address",
+        :long => "--mac-address",
+        :description => "Use a pre-generated MAC address (optional)",
+        :proc => Proc.new { |key| Chef::Config[:knife][:macaddress] = key }
+
       option :xapi_sr,
         :short => "-S Storage repo to provision VM from",
         :long  => "--xapi-sr",


### PR DESCRIPTION
This is a simple modification to allow the user to provision a VM and include a pre-generated MAC address.  It currently doesn't do any checking, but the base functionality works

This helps with #11 
